### PR TITLE
Hide fullscreen button on "mobile"

### DIFF
--- a/lib/elements/kano-app-player-toolbar/kano-app-player-toolbar.html
+++ b/lib/elements/kano-app-player-toolbar/kano-app-player-toolbar.html
@@ -73,10 +73,22 @@
             .icon:focus iron-icon {
                 opacity: 1;
             }
-            
+
             .panel .icon:hover {
                 background-color: var(--color-kano-orange);
             }
+
+            /*
+            XXX: Hide fullscreen button on mobile screens while the
+            functionality until a full responsive solution is in place.
+            `768px` is the current media query value for `kwc-masthead`.
+            */
+            @media (max-width: 768px) {
+                .panel .icon.fullscreen {
+                    display: none;
+                }
+            }
+
         </style>
         <div class="panel">
             <span>


### PR DESCRIPTION
This PR won't solve but prevent the bug described on [this Trello card](https://trello.com/c/PM8Of0mS/1558-hitting-expand-on-expanded-share-card-on-ios-mobile-puts-the-card-in-a-strange-state) to happen in most of the cases.